### PR TITLE
Minifying "split" result files

### DIFF
--- a/src/orthoxml/cli.py
+++ b/src/orthoxml/cli.py
@@ -15,7 +15,8 @@ from orthoxml.custom_parsers import (
     GenePerTaxonStats,
     PrintTaxonomy,
     RootHOGCounter,
-    SplitterByRootHOGS,
+    IndexNthRootHOG,
+    OutputNthRootHOG,
     StreamPairsParser,
     GetGene2IdMapping,
     StreamMaxOGParser,
@@ -133,16 +134,22 @@ def handle_export_ogs(args):
 def handle_split_streaming(args):
     infile_name = args.infile.split("/")[-1]
 
-    with RootHOGCounter(args.infile) as parser:
-        for _ in parser.parse():
-            pass
-        print(f"Count {parser.rhogs_count}")
+    with RootHOGCounter(args.infile) as counter:
+        counter.parse_through()
+        logger.info(f"Processing {counter.rhogs_count} root-level groups...")
 
-    for rhog in range(1, parser.rhogs_count + 1):
-        process_stream_orthoxml(args.infile,
-                        os.path.join(args.outdir, f"{rhog}_{infile_name}"),
-                        parser_cls=SplitterByRootHOGS,
-                        parser_kwargs={"rhogs_number": rhog})
+    for rhog in range(1, counter.rhogs_count + 1):
+
+        with IndexNthRootHOG(args.infile, rhog) as index:
+            index.parse_through()
+            logger.debug(f"Group {rhog} has {len(index.present_genes)} gene refs")
+
+            process_stream_orthoxml(args.infile,
+                                    os.path.join(args.outdir, f"{rhog}_{infile_name}"),
+                                    parser_cls=OutputNthRootHOG,
+                                    parser_kwargs={
+                                        "rhogs_number": rhog,
+                                        "present_genes": index.present_genes})
 
 def handle_conversion_to_nhx(args):
     infile = args.infile

--- a/src/orthoxml/parsers.py
+++ b/src/orthoxml/parsers.py
@@ -1,5 +1,5 @@
 # parsers.py
-
+import os.path
 from logging import getLogger
 from os import PathLike
 from typing import Union, IO, Any, Optional
@@ -110,7 +110,7 @@ class StreamOrthoXMLParser:
         if self._should_close:
             self.stream.close()
 
-    def parse_all(self):
+    def parse_through(self):
         for _ in self.parse():
             pass
 
@@ -183,6 +183,9 @@ def process_stream_orthoxml(
         parser_kwargs=dict(),
         writer_kwargs=dict(),
 ):
+    parent_dir = os.path.dirname(outfile)
+    os.makedirs(parent_dir, exist_ok=True)
+
     with parser_cls(infile, **parser_kwargs) as parser:
         root_tag, nsmap, attrib = parser.root_tag, parser.nsmap, parser.root_attribs
         with writer_cls(outfile, root_tag=root_tag, xmlns=nsmap[''], attrib=attrib, **writer_kwargs) as writer:


### PR DESCRIPTION
This makes files created by `split` only keep the genes and the species they actually refer to, instead of keeping every possible gene that was present in the parent file.